### PR TITLE
create file if not exists

### DIFF
--- a/src/EnumGenie.Core/Writers/FileWriter.cs
+++ b/src/EnumGenie.Core/Writers/FileWriter.cs
@@ -16,7 +16,7 @@ namespace EnumGenie.Writers
 
         public void Write(IReadOnlyCollection<EnumDefinition> enumDefinitions)
         {
-            using (var stream = File.Open(_file, FileMode.Truncate, FileAccess.Write))
+            using (var stream = File.Open(_file, FileMode.OpenOrCreate & FileMode.Truncate, FileAccess.Write))
             {
                 foreach (var definition in enumDefinitions)
                 {


### PR DESCRIPTION
Allow FileWriter to create the output file if it doesn't exist already. Probably constitutes a minor bump, but you're pre-1.0 so it's not really a big deal?

If you're not keen on the idea then I'll go back to checking the file externally.