### PR TITLE
Ability to export const enums

### DIFF
--- a/src/EnumGenie.TypeScript/EnumDeclarationWriter.cs
+++ b/src/EnumGenie.TypeScript/EnumDeclarationWriter.cs
@@ -7,10 +7,18 @@ namespace EnumGenie.TypeScript
 {
     public class EnumDeclarationWriter : IEnumWriter
     {
+        public EnumDeclarationWriter(EnumDeclarationWriterConfig config)
+        {
+            Const = config?.Const ?? false;
+        }
+
+        private bool Const { get; set; }
+
         public void WriteTo(Stream stream, EnumDefinition enumDefinition)
         {
             var writer = new StreamWriter(stream);
-            writer.WriteLine($"export enum {enumDefinition.Name} {{");
+            var writeConst = Const ? "const " : string.Empty;
+            writer.WriteLine($"export {writeConst}enum {enumDefinition.Name} {{");
 
             writer.Write(string.Join($",{Environment.NewLine}", enumDefinition.Members.Select(MemberValueAssignment)));
             writer.WriteLine();

--- a/src/EnumGenie.TypeScript/EnumDeclarationWriterConfig.cs
+++ b/src/EnumGenie.TypeScript/EnumDeclarationWriterConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace EnumGenie.TypeScript
+{
+    public class EnumDeclarationWriterConfig
+    {
+        public bool Const { get; private set; }
+
+        public EnumDeclarationWriterConfig AsConst() { Const = true; return this; }
+    }
+}

--- a/src/EnumGenie.TypeScript/TypeScriptWriterExtensions.cs
+++ b/src/EnumGenie.TypeScript/TypeScriptWriterExtensions.cs
@@ -30,11 +30,16 @@ namespace EnumGenie.TypeScript
         /// <summary>
         /// Outputs just the enum
         /// </summary>
-        public static TypeScriptWriterConfig Declaration(this TypeScriptWriterConfig config)
+        public static TypeScriptWriterConfig Declaration(this TypeScriptWriterConfig config, Action<EnumDeclarationWriterConfig> configureDeclaration = null)
         {
-            config.AddTypeScriptWriter(new EnumDeclarationWriter());
+            var declarationConfig = new EnumDeclarationWriterConfig();
+            configureDeclaration?.Invoke(declarationConfig);
+
+            var writer = new EnumDeclarationWriter(declarationConfig);
+            config.AddTypeScriptWriter(writer);
             return config;
         }
+
         /// <summary>
         /// Outputs functions to get the descriptions of the enums
         /// </summary>


### PR DESCRIPTION
Just works across the board at the moment. I guess const option _might_ be desirable on an enum-by-enum basis.