### PR TITLE
Make Writer.Custom method public to allow for custom writers

### DIFF
--- a/src/EnumGenie.Core/Writers/Writer.cs
+++ b/src/EnumGenie.Core/Writers/Writer.cs
@@ -12,7 +12,7 @@ namespace EnumGenie.Writers
             _enumGenie = enumGenie;
         }
 
-        internal EnumGenie Custom(IWriter writer)
+        public EnumGenie Custom(IWriter writer)
         {
             _enumGenie.AddWriter(writer);
             return _enumGenie;

--- a/src/EnumGenie.Sample/EnumsSummaryStringWriter.cs
+++ b/src/EnumGenie.Sample/EnumsSummaryStringWriter.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.IO;
+using EnumGenie.Writers;
+
+namespace EnumGenie.Sample
+{
+    public class EnumsSummaryStringWriter : IWriter
+    {
+        public string Output { get; private set; }
+
+        public void Write(IReadOnlyCollection<EnumDefinition> enumDefinitions)
+        {
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            {
+                foreach (var definition in enumDefinitions)
+                {
+                    writer.WriteLine($"{definition.EnumType.FullName} ({definition.Members.Count} members)");
+                }
+                writer.Flush();
+
+                stream.Position = 0;
+                Output = reader.ReadToEnd();
+            }
+        }
+    }
+}

--- a/src/EnumGenie.Sample/Program.cs
+++ b/src/EnumGenie.Sample/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using EnumGenie.Filters;
 using EnumGenie.Sample.Enums;
 using EnumGenie.Sources;
@@ -11,12 +12,14 @@ namespace EnumGenie.Sample
     {
         public static void Main()
         {
+            var customWriter = new EnumsSummaryStringWriter();
+
             var genie = new EnumGenie()
                 .SourceFrom.Assembly(typeof(Program).Assembly)
                 .FilterBy.Predicate(t => t != typeof(Ignored))
                 .TransformBy.RenamingEnum(def => def.Name.Replace("StripThisOut", ""))
-                .WriteTo.Console(cfg => 
-                    cfg.TypeScript(ts => 
+                .WriteTo.Console(cfg =>
+                    cfg.TypeScript(ts =>
                         ts.Declaration()
                           .Description()
                           .Descriptor()
@@ -27,9 +30,12 @@ namespace EnumGenie.Sample
                         ts.Declaration(c => c.AsConst())
                             .Description()
                             .Descriptor(c => c.AsConst())
-                    ));
+                    ))
+                .WriteTo.Custom(customWriter);
 
             genie.Write();
+
+            Console.WriteLine("Output from custom writer: " + Environment.NewLine + customWriter.Output);
         }
     }
 }


### PR DESCRIPTION
The Sample project has been updated to include using a custom IWriter which utilises the Writer.Custom method.