### PR TITLE
Allow int16/int64 to be generated

### DIFF
--- a/src/EnumGenie.Core/EnumGenie.cs
+++ b/src/EnumGenie.Core/EnumGenie.cs
@@ -99,17 +99,21 @@ namespace EnumGenie
 
         private static IEnumerable<EnumMemberDefinition> GenerateMemberDefinitions(Type enumType)
         {
-            var memberDefinitions = enumType.GetEnumValues();
+            // get all names for the enum
+            // because enum names must be unique, the values may not be
+            var memberDefinitions = Enum.GetNames(enumType);
 
             foreach (var member in memberDefinitions)
             {
-                object val = Convert.ChangeType(member, Type.GetTypeCode(enumType));
-                yield return EnumMemberDefinition(enumType, val);
+                // get the underlying value regardless of type
+                var enumParsed = Enum.Parse(enumType, member);
+                object val = Convert.ChangeType(enumParsed, Type.GetTypeCode(enumType));
+
+                yield return EnumMemberDefinition(enumType, member, val);
             }
         }
-        private static EnumMemberDefinition EnumMemberDefinition(Type enumType, object value)
+        private static EnumMemberDefinition EnumMemberDefinition(Type enumType, string name, object value)
         {
-            var name = Enum.GetName(enumType, value);
             var member = enumType.GetMember(name)[0];
             var descriptionAttribute = member.GetCustomAttributes(false).OfType<DescriptionAttribute>().FirstOrDefault();
             var description = descriptionAttribute?.Description ?? name;

--- a/src/EnumGenie.Core/EnumGenie.cs
+++ b/src/EnumGenie.Core/EnumGenie.cs
@@ -92,15 +92,22 @@ namespace EnumGenie
 
         private static EnumDefinition EnumDefinition(Type enumType)
         {
-            var memberDefinitions = enumType.GetEnumValues()
-                .Cast<int>()
-                .Select(value => EnumMemberDefinition(enumType, value))
-                .ToList();
+            var memberDefinitions = GenerateMemberDefinitions(enumType).ToList();
 
             return new EnumDefinition(enumType, enumType.Name, memberDefinitions);
         }
 
-        private static EnumMemberDefinition EnumMemberDefinition(Type enumType, int value)
+        private static IEnumerable<EnumMemberDefinition> GenerateMemberDefinitions(Type enumType)
+        {
+            var memberDefinitions = enumType.GetEnumValues();
+
+            foreach (var member in memberDefinitions)
+            {
+                object val = Convert.ChangeType(member, Type.GetTypeCode(enumType));
+                yield return EnumMemberDefinition(enumType, val);
+            }
+        }
+        private static EnumMemberDefinition EnumMemberDefinition(Type enumType, object value)
         {
             var name = Enum.GetName(enumType, value);
             var member = enumType.GetMember(name)[0];

--- a/src/EnumGenie.Core/EnumMemberDefinition.cs
+++ b/src/EnumGenie.Core/EnumMemberDefinition.cs
@@ -4,7 +4,7 @@ namespace EnumGenie
 {
     public class EnumMemberDefinition
     {
-        public EnumMemberDefinition(MemberInfo member, int value, string name, string description)
+        public EnumMemberDefinition(MemberInfo member, object value, string name, string description)
         {
             Value = value;
             Name = name;
@@ -13,7 +13,7 @@ namespace EnumGenie
         }
 
         public MemberInfo Member { get; }
-        public int Value { get; }
+        public object Value { get; }
         public string Name { get; }
         public string Description { get; }
     }

--- a/src/EnumGenie.Sample/Enums/MultipleSameNumber.cs
+++ b/src/EnumGenie.Sample/Enums/MultipleSameNumber.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EnumGenie.Sample.Enums
+{
+    public enum MultipleSameNumber
+    {
+        One = 1,
+        OneOne = 1
+    }
+}

--- a/src/EnumGenie.TypeScript/EnumDescriptorWriter.cs
+++ b/src/EnumGenie.TypeScript/EnumDescriptorWriter.cs
@@ -20,9 +20,9 @@ namespace EnumGenie.TypeScript
             var membersExceptFlagsDefault = enumDefinition.EnumType.GetCustomAttribute<FlagsAttribute>() == null
                 ? enumDefinition.Members
                 : enumDefinition.Members.Where(m => 
-                    m.Member.ReflectedType == typeof(int) && (int)m.Value != 0
-                    || m.Member.ReflectedType == typeof(long) && (long)m.Value != 0
-                    || m.Member.ReflectedType == typeof(byte) && (byte)m.Value != 0
+                    m.Value.GetType() == typeof(int) && (int)m.Value != 0
+                    || m.Value.GetType() == typeof(long) && (long)m.Value != 0
+                    || m.Value.GetType() == typeof(byte) && (byte)m.Value != 0
                 ).ToList();
 
             var varOrConst = _const ? "const" : "var";

--- a/src/EnumGenie.TypeScript/EnumDescriptorWriter.cs
+++ b/src/EnumGenie.TypeScript/EnumDescriptorWriter.cs
@@ -19,7 +19,11 @@ namespace EnumGenie.TypeScript
         {
             var membersExceptFlagsDefault = enumDefinition.EnumType.GetCustomAttribute<FlagsAttribute>() == null
                 ? enumDefinition.Members
-                : enumDefinition.Members.Where(m => m.Value != 0).ToList();
+                : enumDefinition.Members.Where(m => 
+                    m.Member.ReflectedType == typeof(int) && (int)m.Value != 0
+                    || m.Member.ReflectedType == typeof(long) && (long)m.Value != 0
+                    || m.Member.ReflectedType == typeof(byte) && (byte)m.Value != 0
+                ).ToList();
 
             var varOrConst = _const ? "const" : "var";
 


### PR DESCRIPTION
This PR fixes #9. In my case, I have enum's that inherit from `Int16` to match the a database type. This code change allows enums inheriting from Int16/32/64 to be generated correctly.

Additionally, there is a bug fix in this PR to allow enum's sharing the same value to generate valid Typescript instead of the same name repeated multiple times.